### PR TITLE
feat: Allow for charset in Content-Type header

### DIFF
--- a/src/Middleware/SCIMHeaders.php
+++ b/src/Middleware/SCIMHeaders.php
@@ -10,7 +10,7 @@ class SCIMHeaders
 {
     public function handle(Request $request, Closure $next)
     {
-        if ($request->method() != 'GET' && $request->header('content-type') != 'application/scim+json' && $request->header('content-type') != 'application/json' && strlen($request->getContent()) > 0) {
+        if ($request->method() != 'GET' && stripos($request->header('content-type'), 'application/scim+json') === false && stripos($request->header('content-type'), 'application/json') === false && strlen($request->getContent()) > 0) {
             throw new SCIMException(sprintf('The content-type header should be set to "%s"', 'application/scim+json'));
         }
         


### PR DESCRIPTION
The content-type header from Azure Active Directory is `application/scim+json; charset=utf-8`. With this pull request, the SCIMHeaders middleware checks whether the content-type header contains the correct MIME.