### PR TITLE
Potential fix to getNode() when getDefaultSchema() is null

### DIFF
--- a/src/Attribute/AttributeMapping.php
+++ b/src/Attribute/AttributeMapping.php
@@ -512,7 +512,7 @@ class AttributeMapping
         }
 
         //The first schema should be the default one
-        $schema = $attributePath->schema ?? $this->getDefaultSchema()[0];
+        $schema = $attributePath->schema ?? ($this->getDefaultSchema() ? $this->getDefaultSchema()[0] : null);
 
         if (!empty($schema) && !empty($this->getSchema()) && $this->getSchema() != $schema) {
             throw (new SCIMException(sprintf('Trying to get attribute for schema "%s". But schema is already "%s"', $attributePath->schema, $this->getSchema())))->setCode(500)->setScimType('noTarget');


### PR DESCRIPTION
Hello again! I'm trying to finalize the connection between my software and SCIM clients and I've got just a few remaining problems - I've solved almost all the rest.

I'm somehow triggering a null dereference error that I can work-around with the code in this PR. Of course, that doesn't make it right by any means! But I figure rather than show you the change I would make I could just give you a PR with it, and we can certainly close this PR if there's another, better, way to go.

I locally-modified my `./vendors` copy of `laravel-scim-server` to make the enclosed change, and additionally to spit a warning out in the logs whenever it would have errored otherwise.

One of my validation-and-mappings that seems to trigger it is here: 

https://github.com/uberbrady/snipe-it/blob/8f5aadbf26a78c96e843628f8dd32c7ca28b12d4/app/Models/SnipeSCIMConfig.php#L44-L52

When `laravel-scim-server` tries to look up the `email.value` attribute, my check-warning is displayed. It's also quite possible that I should be explicitly setting a "schema" or "defaultSchema" somewhere; and I'd be happy to do that instead, of course! (and of course I'd be happy to contribute back some documentation changes to help explain that, if needed and wanted).

Another setting that seems to trigger the warning is here: 

https://github.com/uberbrady/snipe-it/blob/8f5aadbf26a78c96e843628f8dd32c7ca28b12d4/app/Models/SnipeSCIMConfig.php#L71-L87

 - specifically on the 'formatted', 'streetAddress', 'locality', 'region', 'postalCode', and 'country' attributes - but **not** the 'primary' attribute.
 
The same error also fires on phone.value here: https://github.com/uberbrady/snipe-it/blob/8f5aadbf26a78c96e843628f8dd32c7ca28b12d4/app/Models/SnipeSCIMConfig.php#L60-L68
 
So this enclosed code change *does* seem to make the actual server-level HTTP 500 errors go away, but that doesn't mean it's the right solution. If we really _should_ have a 'schema' or 'defaultSchema' set (and I definitely don't have that) I would also be happy to try to add a new thrown error that will lead the developer down the right path.
 
Thanks again for building this and thanks again for your help as I try to get it fully implemented!