### PR TITLE
Fixed hardcoded schema id in urls for schema controller

### DIFF
--- a/src/Http/Controllers/SchemaController.php
+++ b/src/Http/Controllers/SchemaController.php
@@ -18,9 +18,9 @@ class SchemaController extends Controller
         }
 
         $config = resolve(SCIMConfig::class)->getConfig();
-    
+
         $schemas = [];
-    
+
         foreach ($config as $key => $value) {
             if ($key != 'Users' && $key != 'Group') {
                 continue;
@@ -28,36 +28,36 @@ class SchemaController extends Controller
 
             // TODO: FIX THIS. Schema is now an array but should be a string
             $schema = (new SchemaBuilderV2())->get($value['schema'][0]);
-            
+
             if ($schema == null) {
                 throw new SCIMException("Schema not found");
             }
-            
-            $schema->getMeta()->setLocation(route('scim.schemas', ['id' => '23']));
-            
+
+            $schema->getMeta()->setLocation(route('scim.schemas', ['id' => $schema->getId()]));
+
             $schemas[] = $schema->serializeObject();
         }
-    
+
         $this->schemas = collect($schemas);
 
         return $this->schemas;
     }
-    
+
     public function show($id)
     {
-        $result = $this->schemas->first(
+        $result = $this->getSchemas()->first(
             function ($value, $key) use ($id) {
                 return $value['id'] == $id;
             }
         );
-         
+
         if ($result == null) {
             throw (new SCIMException(sprintf('Resource "%s" not found', $id)))->setCode(404);
         }
-         
+
         return $result;
     }
-    
+
     public function index()
     {
         return new ListResponse($this->getSchemas(), 1, $this->getSchemas()->count());


### PR DESCRIPTION
I was getting a 404 not found and also an error about calling $this->schemas->first(...) on null and I noticed the ID of 23 was hardcoded into the url.