### PR TITLE
Added new ability to override resource query builder

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -343,7 +343,7 @@ class ResourceController extends Controller
 
     public function index(Request $request, PolicyDecisionPoint $pdp, ResourceType $resourceType)
     {
-        $class = $resourceType->getClass();
+        $query = $resourceType->getQuery();
 
         // The 1-based index of the first query result. A value less than 1 SHALL be interpreted as 1.
         $startIndex = max(1, intVal($request->input('startIndex', 0)));
@@ -357,7 +357,7 @@ class ResourceController extends Controller
             $sortBy = Helper::getEloquentSortAttribute($resourceType, $request->input('sortBy'));
         }
 
-        $resourceObjectsBase = $class::when(
+        $resourceObjectsBase = $query->when(
             $filter = $request->input('filter'),
             function ($query) use ($filter, $resourceType) {
                 $parser = new Parser(Mode::FILTER());

--- a/src/ResourceType.php
+++ b/src/ResourceType.php
@@ -2,6 +2,7 @@
 
 namespace ArieTimmerman\Laravel\SCIMServer;
 
+use Illuminate\Support\Arr;
 use ArieTimmerman\Laravel\SCIMServer\Attribute\AttributeMapping;
 
 class ResourceType
@@ -42,7 +43,7 @@ class ResourceType
 
     public function getQuery()
     {
-        return $this->configuration['query'] ?? $this->getClass()::query();
+        return Arr::get($this->configuration, 'query', $this->getClass()::query());
     }
 
     public function getValidations()

--- a/src/ResourceType.php
+++ b/src/ResourceType.php
@@ -40,6 +40,11 @@ class ResourceType
         return $this->configuration['class'];
     }
 
+    public function getQuery()
+    {
+        return $this->configuration['query'] ?? $this->getClass()::query();
+    }
+
     public function getValidations()
     {
         return $this->configuration['validations'];

--- a/src/SCIMConfig.php
+++ b/src/SCIMConfig.php
@@ -25,6 +25,9 @@ class SCIMConfig
             // Set to 'null' to make use of auth.providers.users.model (App\User::class)
             'class' => Helper::getAuthUserClass(),
             
+            // Set to 'null' to make use of new $class
+            'query' => null,
+            
             'validations' => [
     
                 'urn:ietf:params:scim:schemas:core:2.0:User:userName' => 'required',

--- a/src/SCIMConfig.php
+++ b/src/SCIMConfig.php
@@ -25,7 +25,7 @@ class SCIMConfig
             // Set to 'null' to make use of auth.providers.users.model (App\User::class)
             'class' => Helper::getAuthUserClass(),
             
-            // Set to 'null' to make use of new $class
+            // Set to 'null' to make use of $class::query()
             'query' => null,
             
             'validations' => [

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,7 +13,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function boot(\Illuminate\Routing\Router $router)
     {
         $this->loadMigrationsFrom(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'migrations');
-        
+
         $this->publishes([
             __DIR__.'/../config/scim.php' => config_path('scim.php'),
         ], 'laravel-scim');
@@ -25,53 +25,53 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             'resourceType',
             function ($name, $route) {
                 $config = resolve(SCIMConfig::class)->getConfigForResource($name);
-            
+
                 if ($config == null) {
                     throw (new SCIMException(sprintf('No resource "%s" found.', $name)))->setCode(404);
                 }
-            
+
                 return new ResourceType($name, $config);
             }
         );
-        
+
         $router->bind(
             'resourceObject',
             function ($id, $route) {
                 $resourceType = $route->parameter('resourceType');
-            
+
                 if (!$resourceType) {
                     throw (new SCIMException('ResourceType not provided'))->setCode(404);
                 }
-            
-                $class = $resourceType->getClass();
-            
-                $resourceObject = $class::with($resourceType->getWithRelations())->find($id);
-                         
+
+                $query = $resourceType->getQuery();
+
+                $resourceObject = $query->with($resourceType->getWithRelations())->find($id);
+
                 if ($resourceObject == null) {
                     throw (new SCIMException(sprintf('Resource "%s" not found', $id)))->setCode(404);
                 }
-            
+
                 if (($matchIf = \request()->header('IF-Match'))) {
                     $versionsAllowed = preg_split('/\s*,\s*/', $matchIf);
                     $currentVersion = Helper::getResourceObjectVersion($resourceObject);
-                
+
                     //if as version is '*' it is always ok
                     if (!in_array($currentVersion, $versionsAllowed) && !in_array('*', $versionsAllowed)) {
                         throw (new SCIMException('Failed to update.  Resource changed on the server.'))->setCode(412);
                     }
                 }
-            
+
                 return $resourceObject;
             }
         );
-        
+
         $router->middleware('SCIMHeaders', 'ArieTimmerman\Laravel\SCIMServer\Middleware\SCIMHeaders');
 
         if (config('scim.publish_routes')) {
             \ArieTimmerman\Laravel\SCIMServer\RouteProvider::routes();
         }
     }
-    
+
     /**
      * Register the service provider.
      *


### PR DESCRIPTION
This change allows setting up the `SCIMConfig` like this:

```php
return ['query' => User::withTrashed()];
```

Which I needed to be able to map `active` in the schema to my `deleted_at` model and still support activation/deactivation updates.

I tested without the query and with it null (default) and everything still works as expected.