### PR TITLE
Update ResourceType.php

### DIFF
--- a/src/ResourceType.php
+++ b/src/ResourceType.php
@@ -43,7 +43,7 @@ class ResourceType
 
     public function getQuery()
     {
-        return Arr::get($this->configuration, 'query', $this->getClass()::query());
+        return Arr::get($this->configuration, 'query') ?? $this->getClass()::query();
     }
 
     public function getValidations()


### PR DESCRIPTION
Fixed resource default query when not set in config. Arr::get() only provides default value when key doesn't exist in array, not when the keys value is null.  

Resource queries fails without this fix if query is not explicitly set in config