### PR TITLE
Allow Okta-style PUT on users to update Enterprise attributes

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -185,10 +185,10 @@ class ResourceController extends Controller
     public function replace(Request $request, PolicyDecisionPoint $pdp, ResourceType $resourceType, Model $resourceObject, $isMe = false)
     {
         $originalRaw = Helper::objectToSCIMArray($resourceObject, $resourceType);
-        $original = Helper::flatten($originalRaw, $resourceType->getSchema());
+        $original = Helper::flatten($originalRaw, $request->input()['schemas']);
 
         //TODO: get flattend from $resourceObject
-        $flattened = Helper::flatten($request->input(), $resourceType->getSchema());
+        $flattened = Helper::flatten($request->input(), $request->input()['schemas']);
         $flattened = $this->validateScim($resourceType, $flattened, $resourceObject);
 
         $updated = [];


### PR DESCRIPTION
It turns out that when Okta updates user attributes, it does so with a `PUT` to the User object to replace all of the attributes. That seems to generally work, however, when you try to update any of the Enterprise-namespaced attributes, the updates will silently be ignored.

I think (but I am definitely not sure!) it's because the arguments we pass to Flatten aren't including all of the namespaces. This change should fix that - but I'm open to other approaches if there are better ways to go about it.

Thanks again for this lovely software - and if it turns out that you don't need this PR or don't want to take it, no worries - you can close it, and it won't hurt my feelings.