### PR TITLE
Add support for Laravel 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,27 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
-        laravel: [6.*, 7.*, 8.*, 9.*]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        laravel: [6.*, 7.*, 8.*, 9.*, 10.*]
         exclude:
           - laravel: 6.*
             php: 8.1
+          - laravel: 6.*
+            php: 8.2
           - laravel: 7.*
             php: 8.1
-          - laravel: 8.*
-            php: 7.2
+          - laravel: 7.*
+            php: 8.2
           - laravel: 9.*
             php: 7.3
           - laravel: 9.*
             php: 7.4
+          - laravel: 10.*
+            php: 7.3
+          - laravel: 10.*
+            php: 7.4
+          - laravel: 10.*
+            php: 8.0
 
     name: PHP ${{ matrix.php }} on Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
 		"php": "^7.0|^8.0",
-        "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "tmilos/scim-schema": "^0.1.0",
         "tmilos/scim-filter-parser": "^1.3"
     },
@@ -29,10 +29,10 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0",
         "laravel/legacy-factories": "*"
     },
-    
+
     "extra": {
 	    "laravel": {
 	        "providers": [
@@ -43,5 +43,5 @@
 	        }
 	    }
 	}
-	
+
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticProperties="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
 >
   <testsuites>
     <testsuite name="Unit tests">


### PR DESCRIPTION
This merge request adds support for Laravel 10 in composer.json and Github Actions.

In addition to these changes, I had to upgrade the `phpunit.xml` file because the new `orchestra/testbench` package uses a version of PHPUnit that is not compatible with the existing format.