### PR TITLE
Fixes #40 - change the ID attribute to always be a string, as per spec.

### DIFF
--- a/src/SCIMConfig.php
+++ b/src/SCIMConfig.php
@@ -55,7 +55,11 @@ class SCIMConfig
             // Map a SCIM attribute to an attribute of the object.
             'mapping' => [
                 
-                'id' => AttributeMapping::eloquent("id")->disableWrite(),
+                'id' => (new AttributeMapping())->setRead(
+                    function (&$object) {
+                        return (string)$object->id;
+                    }
+                )->disableWrite(),
                 
                 'externalId' => null,
                 


### PR DESCRIPTION
As mentioned in #40 , JumpCloud insists on ID's actually being strings. For some reason all of the other SCIM clients I've worked with don't seem to care, but JumpCloud really does.

I considered seeing if there was a better way to do this - perhaps using the `string|required` validation to forcibly cast objects to be strings when they should be, but the only output I found from the Users endpoint that had the 'raw integer' problem seemed to be the ID.

So, instead, I just changed our SCIM config to do a custom Read function that casts the ID to a string. It seems to fix the problem in our project, so I thought I would contribute the same back here.

Thanks again for this wonderful project, and for all the work you do! And please do let me know if you think there might be a better approach to handle this more systematically - though, do note, I didn't see any other output that had the same problem so I don't know if it's exactly necessary.