### PR TITLE
fix: set default schema on sub node in AttributeMapping

### DIFF
--- a/src/Attribute/AttributeMapping.php
+++ b/src/Attribute/AttributeMapping.php
@@ -539,6 +539,10 @@ class AttributeMapping
         foreach ($elements as $element) {
             try {
                 $node = $node->getSubNode($element, $schema);
+
+                if ($node instanceof AttributeMapping && $this->getDefaultSchema()) {
+                    $node->setDefaultSchema($this->getDefaultSchema());
+                }
             } catch (\Exception $e) {
                 throw $e;
             }


### PR DESCRIPTION
This fixes the same issue as #19, but instead of ignoring the error it sets the default schema on the subnode.
This means that the email value has the correct default schema and there are no errors. 

cc @uberbrady @arietimmerman 